### PR TITLE
Add Nix flake

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
 * [⬇️ Installation](get-started/installation/README.md)
   * [Windows](get-started/installation/windows.md)
   * [Linux](get-started/installation/linux.md)
+  * [NixOS](get-started/installation/nixos.md)
   * [MacOS](get-started/installation/macos.md)
 * [🛠️ Usage](get-started/usage/README.md)
   * [📖 Concepts](get-started/usage/concepts.md)

--- a/docs/get-started/installation/nixos.md
+++ b/docs/get-started/installation/nixos.md
@@ -1,0 +1,147 @@
+---
+icon: snowflake
+description: If you're using NixOS follow this guide!
+---
+
+# NixOS
+
+VS Launcher can be installed on NixOS through a Nix flake that provides a proper `vs-launcher` derivation and a [Home Manager](https://github.com/nix-community/home-manager) module to easily add working versions.
+
+{% stepper %}
+{% step %}
+#### Add it as a flake input
+
+```Nix
+# flake.nix
+# ...
+inputs = {
+  vs-launcher.url = "github:XurxoMF/vs-launcher";
+};
+# ...
+```
+{% endstep %}
+
+{% step %}
+#### Import the Home Manager module
+
+```Nix
+# home.nix
+{inputs, ...}: {
+  imports = [inputs.vintagestory-nix.homeManagerModules.default];
+}
+```
+{% endstep %}
+
+{% step %}
+#### Configure using the Home Manager module
+
+```Nix
+# home.nix
+{inputs, pkgs, ...}: {
+  imports = [inputs.vintagestory-nix.homeManagerModules.default];
+
+  programs.vs-launcher = {
+    enable = true; # Install VS Launcher and activate the module
+    installedVersions = [ # Versions to link into ~/.config/VSLGameVersions
+      # Unless using an overlay, this will be the latest version from nixpkgs
+      pkgs.vintagestory
+    ];
+  };
+}
+```
+
+{% hint style="warning" %}
+Game versions installed using VS Launcher likely won't work as they won't be able to find a .NET installation.
+`vs-launcher.installedVersions` substitutes the non NixOS compatible `Vintagestory` binary with the derivation's wrapped one.
+{% endhint %}
+
+{% hint style="info" %}
+It is up to you to manage the packages in `vs-launcher.installedVersions`, I may recommend pinning `pkgs.vintagestory`'s version using `overrideAttrs` so it doesn't change by itself.
+
+You could also pin multiple versions to install them individually, see [Additional tips](https://vsldocs.xurxomf.xyz/get-started/installation/nixos#additional-tips).
+{% endhint %}
+
+{% hint style="info" %}
+Versions installed using the Home Manager module have to be manually registered inside VS Launcher.
+{% endhint %}
+{% endstep %}
+
+***
+
+## Additional tips
+
+Here are a few additional tips to help you on your journey:
+
+### Install multiple Vintage Story versions
+
+```Nix
+# home.nix
+{inputs, pkgs, ...}: let
+  mkVintageStory = {version, hash}: pkgs.vintagestory.overrideAttrs {
+    inherit version;
+    src = fetchurl {
+      url = "https://cdn.vintagestory.at/gamefiles/stable/vs_client_linux-x64_${version}.tar.gz";
+      inherit hash;
+    };
+  };
+in{
+  imports = [inputs.vintagestory-nix.homeManagerModules.default];
+  programs.vs-launcher = {
+    enable = true;
+    installedVersions = [
+      (mkVintageStory {
+        version = "1.20.4";
+        hash = "sha256-Hgp2u/y2uPnJhAmPpwof76/woFGz4ISUXU+FIRMjMuQ=";
+      })
+      (mkVintageStory {
+        version = "1.20.3";
+        hash = "sha256-+nEyFlLfTAOmd8HrngZOD1rReaXCXX/ficE/PCLcewg=";
+      })
+    ];
+  };
+}
+```
+
+### Replace insecure .NET 7 with .NET 8
+
+Here is a `pkgs.vintagestory` override that replaces `dotnet-runtime_7` with `dotnet-runtime_8`.
+
+You can, of course, also pin the version using a method similar to the previous tip.
+```Nix
+vintagestory.overrideAttrs (prevAttrs: {
+  buildInputs = [ dotnet-runtime_8 ];
+  preFixup = ''
+    makeWrapper ${dotnet-runtime_8}/bin/dotnet $out/bin/vintagestory \
+      --prefix LD_LIBRARY_PATH : "${prevAttrs.runtimeLibs}" \
+      --set DOTNET_ROOT ${dotnet-runtime_8}/share/dotnet \
+      --set DOTNET_ROLL_FORWARD Major \
+      --add-flags $out/share/vintagestory/Vintagestory.dll
+
+    makeWrapper ${dotnet-runtime_8}/bin/dotnet $out/bin/vintagestory-server \
+      --prefix LD_LIBRARY_PATH : "${prevAttrs.runtimeLibs}" \
+      --set DOTNET_ROOT ${dotnet-runtime_8}/share/dotnet \
+      --set DOTNET_ROLL_FORWARD Major \
+      --add-flags $out/share/vintagestory/VintagestoryServer.dll
+
+    find "$out/share/vintagestory/assets/" -not -path "/fonts/" -regex "./.[A-Z]." | while read -r file; do
+      local filename="$(basename -- "$file")"
+      ln -sf "$filename" "''${file%/}"/"''${filename,,}"
+    done
+  '';
+})
+```
+
+### Fix RAM limits
+
+```Nix
+# configuration.nix
+boot.kernel.sysctl = {
+  "vm.max_map_count" = 262144;
+};
+```
+
+***
+
+{% hint style="info" %}
+If you find any issue report it on the [GitHub Issue Tracker](https://github.com/XurxoMF/vs-launcher/issues) and if you need help as us on the [GitHub Discussions](https://github.com/XurxoMF/vs-launcher/discussions) or on the [Official Vintage Story Discord Server](https://discord.com/channels/302152934249070593/1314991001571557488).
+{% endhint %}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1740126099,
+        "narHash": "sha256-ozoOtE2hGsqh4XkTJFsrTkNxkRgShxpQxDynaPZUGxk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "32fb99ba93fea2798be0e997ea331dd78167f814",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Unofficial launcher and version manager for Vintage Story";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {inherit system; config.allowUnfree = true;};
+  in {
+    packages.${system} = {
+      default = self.packages.${system}.vs-launcher;
+      vs-launcher = pkgs.callPackage ./nix { };
+    };
+
+    homeManagerModules = {
+      default = self.homeManagerModules.vs-launcher;
+      vs-launcher = import ./nix/hm.nix self.packages.${system}.vs-launcher;
+    };
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenvNoCC
+, appimageTools
+, fetchurl
+}: let
+  pname = "vs-launcher";
+  version = "1.2.3";
+
+  appImageSrc = fetchurl {
+    url = "https://github.com/XurxoMF/vs-launcher/releases/download/${version}/vs-launcher-${version}.AppImage";
+    sha256 = "1dxiryy3wdbybxr2kl3lmvkzvikfmp0x49zdj6f31jd02gvpnhf6";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version;
+    src = appImageSrc;
+  };
+in stdenvNoCC.mkDerivation rec {
+  inherit pname version;
+
+  src = appimageTools.wrapType2 {
+    inherit pname version;
+    src = appImageSrc;
+    profile=''
+      export APPIMAGE=true
+    '';
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r $src/bin $out
+
+    mkdir -p $out/share/applications
+    cp -r ${appimageContents}/usr/share/icons $out/share
+    cp ${appimageContents}/${pname}.desktop $out/share/applications
+    sed -i 's/^Exec=AppRun.*/Exec=${pname}/' $out/share/applications/${pname}.desktop
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Unofficial launcher and version manager for Vintage Story";
+    homepage = "https://github.com/XurxoMF/vs-launcher";
+    downloadPage = "https://github.com/XurxoMF/vs-launcher/releases";
+    license = licenses.unfree;
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = pname;
+  };
+}

--- a/nix/hm.nix
+++ b/nix/hm.nix
@@ -1,0 +1,39 @@
+vs-launcher: {
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib) mkIf mkEnableOption mkOption types;
+  cfg = config.programs.vs-launcher;
+in {
+  options.programs.vs-launcher = {
+    enable = mkEnableOption "VS Launcher";
+    installedVersions = mkOption {
+      type = types.listOf types.package;
+      default = [];
+      description = "List of Vintage Story packages to add to VS Launcher's GameVersions directory";
+    };
+  };
+  config = mkIf cfg.enable {
+    home.packages = [vs-launcher];
+
+    xdg.configFile = builtins.listToAttrs (builtins.map (
+        vs: {
+          name = "VSLGameVersions/${vs.version}";
+          value.source = pkgs.stdenv.mkDerivation {
+            pname = "VSLGameVersion";
+            inherit (vs) version;
+            phases = ["installPhase"];
+            installPhase = ''
+              cp -r ${vs}/share/vintagestory $out
+              chmod +w $out
+              mv $out/Vintagestory $out/Vintagestory-unwrapped
+              cp ${vs}/bin/vintagestory $out/Vintagestory
+            '';
+          };
+        }
+      )
+      cfg.installedVersions);
+  };
+}


### PR DESCRIPTION
Running VS Launcher with an appimage or a .deb does not work on NixOS, additionally, Vintage Story versions installed inside VSL won't launch as they won't be able to find a dotnet installation.

This PR adds a Nix flake that lets the user easily install VSL and VS versions through a [Home Manager](https://github.com/nix-community/home-manager) module in a NixOS compatible way.

I have also added a "NixOS" installation page to the docs with examples.

This is a draft PR because there are still issues with the code and I wanted to have some feedback, maybe even some help.
- [ ] Launching VS Launcher through the .desktop file starts the process but no window appears.
- [ ] Sometimes, for no apparent reasons, the application will fail to create a window and throw a `libEGL warning: egl: failed to create dri2 screen`. This appears/disappears with boots and reboots, may be an issue with my machine tho.

I'm not an experienced programmer, Nix or English user, so please excuse any obvious mistake.

## Files breakdown
- `flake.nix`: The entry file to the Nix configuration.
- `nix/default.nix`: VSL's Nix derivation, instructions on how to install the application.
I would have preferred it to compile the code from source but couldn't figure it out, instead, it extracts the appimage and patches it.
- `nix/hm.nix`: The Home Manager module.
Adds a `programs.vs-launcher` option set with `enable` to install VS Launcher and `installedVersions` to install Vintage Story versions.
`installedVersions` copies the game's files into a separate derivation, then replaces the `Vintagestory` binary with the one wrapped by Nix.

## Maintenance
Keeping the flake up-to-date is an added maintenance but it shouldn't be very difficult.

1. Have Nix installed
2. Change the version variable inside the `flake.nix` to the latest release's
3. Use [`nix-prefetch-url <url-to-the-appimage>`](https://man.archlinux.org/man/extra/nix/nix-prefetch-url.1.en) to get the new sha256

I'm not aware of some more automated way of doing it.

## Example usage
The added docs contains some examples, but here is the configuration I use myself.
<details>
  <summary>my config</summary>

  ```Nix
{
  inputs,
  pkgs,
  ...
}: {
  imports = [inputs.vintagestory-nix.homeManagerModules.default];
  home.packages = [ pkgs.vintagestory ];

  programs.vs-launcher = let
    inherit (pkgs) fetchurl dotnet-runtime_8;
    mkVintageStory = {version, hash}: pkgs.vintagestory.overrideAttrs (prevAttrs: rec {
      inherit version;
      src = fetchurl {
        url = "https://cdn.vintagestory.at/gamefiles/stable/vs_client_linux-x64_${version}.tar.gz";
        inherit hash;
      };
      buildInputs = [ dotnet-runtime_8 ];
      preFixup = ''
        makeWrapper ${dotnet-runtime_8}/bin/dotnet $out/bin/vintagestory \
          --prefix LD_LIBRARY_PATH : "${prevAttrs.runtimeLibs}" \
          --set DOTNET_ROOT ${dotnet-runtime_8}/share/dotnet \
          --set DOTNET_ROLL_FORWARD Major \
          --add-flags $out/share/vintagestory/Vintagestory.dll

        makeWrapper ${dotnet-runtime_8}/bin/dotnet $out/bin/vintagestory-server \
          --prefix LD_LIBRARY_PATH : "${prevAttrs.runtimeLibs}" \
          --set DOTNET_ROOT ${dotnet-runtime_8}/share/dotnet \
          --set DOTNET_ROLL_FORWARD Major \
          --add-flags $out/share/vintagestory/VintagestoryServer.dll

        find "$out/share/vintagestory/assets/" -not -path "/fonts/" -regex "./.[A-Z]." | while read -r file; do
          local filename="$(basename -- "$file")"
          ln -sf "$filename" "''${file%/}"/"''${filename,,}"
        done
      '';
    });
  in {
    enable = true;
    installedVersions = [
      (mkVintageStory {
        version = "1.20.4";
        hash = "sha256-Hgp2u/y2uPnJhAmPpwof76/woFGz4ISUXU+FIRMjMuQ=";
      })
      (mkVintageStory {
        version = "1.20.3";
        hash = "sha256-+nEyFlLfTAOmd8HrngZOD1rReaXCXX/ficE/PCLcewg=";
      })
    ];
  };
}
  ```
</details>

---
Completely unrelated, but could I ask why is VS Launcher proprietary software? I'd love see it get a nice FOSS license.