### PR TITLE
Add macOS support for game launching, downloads, and error reporting

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -25,6 +25,10 @@ nsis:
   oneClick: false
   runAfterFinish: true
 mac:
+  target:
+    - target: dmg
+      arch:
+        - arm64
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@headlessui/react": "^2.2.0",
         "@tailwindcss/postcss": "^4.0.8",
         "archiver": "^7.0.1",
-        "axios": "^1.7.9",
+        "axios": "1.14.0",
         "clsx": "^2.1.1",
         "electron-log": "^5.2.3",
         "electron-updater": "^6.1.7",
@@ -3352,14 +3352,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -5710,9 +5710,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -8225,10 +8225,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@headlessui/react": "^2.2.0",
     "@tailwindcss/postcss": "^4.0.8",
     "archiver": "^7.0.1",
-    "axios": "^1.7.9",
+    "axios": "1.14.0",
     "clsx": "^2.1.1",
     "electron-log": "^5.2.3",
     "electron-updater": "^6.1.7",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -165,6 +165,7 @@ declare global {
     releaseDate: string
     windows: string
     linux: string
+    macos: string
   }
 
   type DownloadableModAuthorType = {

--- a/src/ipc/handlers/gameHandlers.ts
+++ b/src/ipc/handlers/gameHandlers.ts
@@ -6,7 +6,7 @@ import os from "os"
 import { logMessage } from "@src/utils/logManager"
 import { IPC_CHANNELS } from "@src/ipc/ipcChannels"
 
-ipcMain.handle(IPC_CHANNELS.GAME_MANAGER.EXECUTE_GAME, async (_event, version: GameVersionType, installation: InstallationType, account: AccountType | null): Promise<boolean> => {
+ipcMain.handle(IPC_CHANNELS.GAME_MANAGER.EXECUTE_GAME, async (_event, version: GameVersionType, installation: InstallationType, account: AccountType | null): Promise<{ success: boolean; error?: string }> => {
   logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Trying to run Vintage Story ${version.version} from ${version.path} on ${installation.path}.`)
 
   const processEnv = installation.envVars.split(",").reduce((acc, entry) => {
@@ -36,12 +36,12 @@ ipcMain.handle(IPC_CHANNELS.GAME_MANAGER.EXECUTE_GAME, async (_event, version: G
         params = [join(version.path, "Vintagestory.exe"), `--dataPath=${installation.path}`, installation.startParams]
       } else {
         logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Couldn't find a way to run Vintage Story, aborting...`)
-        return false
+        return { success: false, error: "Couldn't find Vintagestory binary in game folder" }
       }
     } catch (err) {
       logMessage("error", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Error detecting how to run Vintage Story.`)
       logMessage("verbose", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Error detecting how to run Vintage Story: ${err}`)
-      return false
+      return { success: false, error: `Error detecting how to run Vintage Story: ${err}` }
     }
   } else if (os.platform() === "win32") {
     logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Windows platform detected.`)
@@ -55,23 +55,45 @@ ipcMain.handle(IPC_CHANNELS.GAME_MANAGER.EXECUTE_GAME, async (_event, version: G
         params = [`--dataPath=${installation.path}`, installation.startParams]
       } else {
         logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Couldn't find a way to run Vintage Story, aborting...`)
-        return false
+        return { success: false, error: "Couldn't find Vintagestory.exe in game folder" }
       }
     } catch (err) {
       logMessage("error", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Error detecting how to run Vintage Story.`)
       logMessage("verbose", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Error detecting how to run Vintage Story: ${err}`)
-      return false
+      return { success: false, error: `Error detecting how to run Vintage Story: ${err}` }
     }
   } else if (os.platform() === "darwin") {
-    logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] MacOS platform detected. Not yet supported.`)
-    return false
+    logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] macOS platform detected.`)
+
+    try {
+      const files = fse.readdirSync(version.path)
+      const appBundle = files.find((f) => f.endsWith(".app"))
+      const innerBinary = appBundle ? join(version.path, appBundle, "Contents", "MacOS", "Vintagestory") : null
+
+      if (appBundle && innerBinary && fse.existsSync(innerBinary)) {
+        logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Found .app bundle: ${appBundle}`)
+        command = "arch"
+        params = ["-x86_64", innerBinary, `--dataPath=${installation.path}`, installation.startParams]
+      } else if (files.includes("Vintagestory")) {
+        logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Vintagestory binary found.`)
+        command = "arch"
+        params = ["-x86_64", join(version.path, "Vintagestory"), `--dataPath=${installation.path}`, installation.startParams]
+      } else {
+        logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Couldn't find a way to run Vintage Story, aborting...`)
+        return { success: false, error: "Couldn't find Vintagestory binary or .app bundle in game folder" }
+      }
+    } catch (err) {
+      logMessage("error", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Error detecting how to run Vintage Story.`)
+      logMessage("verbose", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Error detecting how to run Vintage Story: ${err}`)
+      return { success: false, error: `Error detecting how to run Vintage Story: ${err}` }
+    }
   } else {
-    logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Not platform detected.`)
-    return false
+    logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] No platform detected.`)
+    return { success: false, error: `Unsupported platform: ${os.platform()}` }
   }
 
   if (command && params) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       if (account) {
         logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Logged in. Setting session keys.`)
 
@@ -117,30 +139,37 @@ ipcMain.handle(IPC_CHANNELS.GAME_MANAGER.EXECUTE_GAME, async (_event, version: G
       logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Running Vintagestory with ${command} + ${params.join(" + ")}.`)
 
       const externalApp = spawn(command, params, { env })
+      const stderrChunks: string[] = []
 
       externalApp.stdout.on("data", (data) => {
         logMessage("verbose", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] ${data}`)
       })
 
       externalApp.stderr.on("data", (data) => {
+        const message = data.toString()
+        stderrChunks.push(message)
         logMessage("error", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Vintage Story threw an error! Check verbose logs for more info.`)
         logMessage("verbose", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] ${data}`)
       })
 
       externalApp.on("close", (code) => {
         logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Vintage Story closed: ${code}`)
-        resolve(true)
+        if (code !== 0 && stderrChunks.length > 0) {
+          resolve({ success: false, error: stderrChunks.join("").trim().slice(-500) })
+        } else {
+          resolve({ success: true })
+        }
       })
 
       externalApp.on("error", (error) => {
         logMessage("error", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] Error running Vintage Story.`)
         logMessage("verbose", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] ${error}`)
-        reject(false)
+        resolve({ success: false, error: `Failed to start process: ${error.message}` })
       })
     })
   } else {
     logMessage("error", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [EXECUTE_GAME] No command or params found.`)
-    return false
+    return { success: false, error: "No command or params found" }
   }
 })
 
@@ -195,10 +224,32 @@ ipcMain.handle(IPC_CHANNELS.GAME_MANAGER.LOOK_FOR_A_GAME_VERSION, async (_event,
       return false
     }
   } else if (os.platform() === "darwin") {
-    logMessage("info", `[back] [ipc] [ipc/handlers/pathsHandlers.ts] [LOOK_FOR_A_GAME_VERSION] MacOS platform detected. Not yet supported.`)
-    return false
+    logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [LOOK_FOR_A_GAME_VERSION] macOS platform detected.`)
+
+    try {
+      const files = fse.readdirSync(path)
+      const appBundle = files.find((f) => f.endsWith(".app"))
+      const innerBinary = appBundle ? join(path, appBundle, "Contents", "MacOS", "Vintagestory") : null
+
+      if (appBundle && innerBinary && fse.existsSync(innerBinary)) {
+        logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [LOOK_FOR_A_GAME_VERSION] Found .app bundle: ${appBundle}`)
+        command = "arch"
+        params = ["-x86_64", innerBinary, `-v`]
+      } else if (files.includes("Vintagestory")) {
+        logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [LOOK_FOR_A_GAME_VERSION] Vintagestory binary found.`)
+        command = "arch"
+        params = ["-x86_64", join(path, "Vintagestory"), `-v`]
+      } else {
+        logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [LOOK_FOR_A_GAME_VERSION] Couldn't find Vintage Story in that folder.`)
+        return false
+      }
+    } catch (err) {
+      logMessage("error", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [LOOK_FOR_A_GAME_VERSION] Error looking for Vintage Story.`)
+      logMessage("verbose", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [LOOK_FOR_A_GAME_VERSION] Error looking for Vintage Story: ${err}`)
+      return false
+    }
   } else {
-    logMessage("info", `[back] [ipc] [ipc/handlers/pathsHandlers.ts] [LOOK_FOR_A_GAME_VERSION] Not platform detected.`)
+    logMessage("info", `[back] [ipc] [ipc/handlers/gameHandlers.ts] [LOOK_FOR_A_GAME_VERSION] No platform detected.`)
     return false
   }
 

--- a/src/ipc/handlers/pathsHandlers.ts
+++ b/src/ipc/handlers/pathsHandlers.ts
@@ -3,6 +3,7 @@ import fse from "fs-extra"
 import { join, sep } from "path"
 import os from "os"
 import { Worker } from "worker_threads"
+import { execFile } from "child_process"
 
 import { logMessage } from "@src/utils/logManager"
 import { IPC_CHANNELS } from "@src/ipc/ipcChannels"
@@ -172,7 +173,7 @@ ipcMain.handle(IPC_CHANNELS.PATHS_MANAGER.COMPRESS_ON_PATH, async (event, id: st
 })
 
 ipcMain.handle(IPC_CHANNELS.PATHS_MANAGER.CHANGE_PERMS, async (_event, paths: string[], perms: number) => {
-  if (os.platform() === "linux") {
+  if (os.platform() === "linux" || os.platform() === "darwin") {
     return new Promise((resolve, reject) => {
       logMessage("info", `[back] [ipc] [ipc/handlers/pathsHandlers.ts] [CHANGE_PERMS] Changing perms to ${paths.length} paths.`)
 
@@ -204,6 +205,24 @@ ipcMain.handle(IPC_CHANNELS.PATHS_MANAGER.CHANGE_PERMS, async (_event, paths: st
   }
 
   return Promise.reject(true)
+})
+
+ipcMain.handle(IPC_CHANNELS.PATHS_MANAGER.REMOVE_QUARANTINE, async (_event, path: string): Promise<boolean> => {
+  if (os.platform() !== "darwin") return true
+
+  logMessage("info", `[back] [ipc] [ipc/handlers/pathsHandlers.ts] [REMOVE_QUARANTINE] Removing quarantine attribute from ${path}.`)
+
+  return new Promise((resolve) => {
+    execFile("xattr", ["-rd", "com.apple.quarantine", path], (err) => {
+      if (err) {
+        logMessage("warn", `[back] [ipc] [ipc/handlers/pathsHandlers.ts] [REMOVE_QUARANTINE] Failed to remove quarantine: ${err.message}`)
+        resolve(false)
+      } else {
+        logMessage("info", `[back] [ipc] [ipc/handlers/pathsHandlers.ts] [REMOVE_QUARANTINE] Quarantine attribute removed.`)
+        resolve(true)
+      }
+    })
+  })
 })
 
 ipcMain.handle(IPC_CHANNELS.PATHS_MANAGER.COPY_TO_ICONS, async (_event, path: string, name: string): Promise<{ status: true; file: string } | { status: false }> => {

--- a/src/ipc/ipcChannels.ts
+++ b/src/ipc/ipcChannels.ts
@@ -36,6 +36,7 @@ export const IPC_CHANNELS = {
     EXTRACT_PROGRESS: "extract-progress",
     COMPRESS_PROGRESS: "compress-progress",
     CHANGE_PERMS: "change-perms",
+    REMOVE_QUARANTINE: "remove-quarantine",
     COPY_TO_ICONS: "copy-to-icons"
   },
   GAME_MANAGER: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -46,10 +46,11 @@ const api: BridgeAPI = {
     onExtractProgress: (callback: ProgressCallback) => ipcRenderer.on(IPC_CHANNELS.PATHS_MANAGER.EXTRACT_PROGRESS, callback),
     onCompressProgress: (callback: ProgressCallback) => ipcRenderer.on(IPC_CHANNELS.PATHS_MANAGER.COMPRESS_PROGRESS, callback),
     changePerms: (paths: string[], perms: number): Promise<boolean> => ipcRenderer.invoke(IPC_CHANNELS.PATHS_MANAGER.CHANGE_PERMS, paths, perms),
+    removeQuarantine: (path: string): Promise<boolean> => ipcRenderer.invoke(IPC_CHANNELS.PATHS_MANAGER.REMOVE_QUARANTINE, path),
     copyToIcons: (path: string, name: string): Promise<{ status: true; file: string } | { status: false }> => ipcRenderer.invoke(IPC_CHANNELS.PATHS_MANAGER.COPY_TO_ICONS, path, name)
   },
   gameManager: {
-    executeGame: (version: GameVersionType, installation: InstallationType, account: AccountType | null): Promise<boolean> =>
+    executeGame: (version: GameVersionType, installation: InstallationType, account: AccountType | null): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke(IPC_CHANNELS.GAME_MANAGER.EXECUTE_GAME, version, installation, account),
     lookForAGameVersion: (path: string): Promise<{ exists: boolean; installedGameVersion: string | undefined }> => ipcRenderer.invoke(IPC_CHANNELS.GAME_MANAGER.LOOK_FOR_A_GAME_VERSION, path)
   },

--- a/src/preload/preload.d.ts
+++ b/src/preload/preload.d.ts
@@ -43,10 +43,11 @@ declare global {
       onExtractProgress: (callback: ProgressCallback) => void
       onCompressProgress: (callback: ProgressCallback) => void
       changePerms: (paths: string[], perms: number) => void
+      removeQuarantine: (path: string) => Promise<boolean>
       copyToIcons: (path: string, name: string) => Promise<{ status: true; file: string } | { status: false }>
     }
     gameManager: {
-      executeGame: (version: GameVersionType, installation: InstallationType, account: AccountType | null) => Promise<boolean>
+      executeGame: (version: GameVersionType, installation: InstallationType, account: AccountType | null) => Promise<{ success: boolean; error?: string }>
       lookForAGameVersion: (path: string) => Promise<{ exists: boolean; installedGameVersion: string | undefined }>
     }
     netManager: {

--- a/src/renderer/src/components/layout/MainMenu.tsx
+++ b/src/renderer/src/components/layout/MainMenu.tsx
@@ -69,12 +69,18 @@ function MainMenu(): JSX.Element {
       }
 
       const startedPlaying = Date.now()
-      const closeStatus = await window.api.gameManager.executeGame(gameVersionToRun, selectedInstallation, config.account)
+      const result = await window.api.gameManager.executeGame(gameVersionToRun, selectedInstallation, config.account)
       const finishedPlaying = Date.now()
       const ttp = finishedPlaying - startedPlaying + selectedInstallation.totalTimePlayed
       configDispatch({ type: CONFIG_ACTIONS.EDIT_INSTALLATION, payload: { id: selectedInstallation.id, updates: { _playing: false, lastTimePlayed: finishedPlaying, totalTimePlayed: ttp } } })
       configDispatch({ type: CONFIG_ACTIONS.EDIT_GAME_VERSION, payload: { version: gameVersionToRun.version, updates: { _playing: false } } })
-      if (!closeStatus) return addNotification(t("notifications.body.gameExitedWithErrors"), "error")
+      if (!result.success) {
+        const openLogs = async (): Promise<void> => {
+          const logsPath = await window.api.pathsManager.formatPath([await window.api.pathsManager.getCurrentUserDataPath(), "VSLauncher", "Logs"])
+          window.api.pathsManager.openPathOnFileExplorer(logsPath)
+        }
+        return addNotification(`${t("notifications.body.gameExitedWithErrors")}${result.error ? ` ${result.error}` : ""}`, "error", { onClick: openLogs, duration: 15_000 })
+      }
     } catch (err) {
       addNotification(t("notifications.body.errorExecutingGame"), "error")
     } finally {

--- a/src/renderer/src/contexts/TaskManagerContext.tsx
+++ b/src/renderer/src/contexts/TaskManagerContext.tsx
@@ -172,6 +172,7 @@ export const TaskProvider = ({ children }: { children: React.ReactNode }): JSX.E
       if (!result) throw new Error("Extraction failed")
 
       window.api.pathsManager.changePerms([outputPath], 0o755)
+      window.api.pathsManager.removeQuarantine(outputPath)
 
       window.api.utils.logMessage("info", `[front] [tasks] [contexts/TaskManagercontext.tsx] [TaskProvider > startExtract] [${id}] [${filePath}] Extracted.`)
       if (notifications === "all" || notifications === "end") addNotification(t("notifications.body.extracted", { extractName: name }), "success")

--- a/src/renderer/src/features/versions/pages/AddVersion.tsx
+++ b/src/renderer/src/features/versions/pages/AddVersion.tsx
@@ -73,7 +73,7 @@ function AddVersion(): JSX.Element {
       return addNotification(t("features.versions.folderAlreadyInUse"), "error")
 
     const os = await window.api.utils.getOs()
-    const url = os === "win32" ? version.windows : version.linux
+    const url = os === "win32" ? version.windows : os === "darwin" ? version.macos : version.linux
 
     const newGameVersion: GameVersionType = {
       version: version.version,


### PR DESCRIPTION
- Add macOS game execution via arch -x86_64 with .app bundle and bare binary detection
- Fix .app bundle detection matching non-game bundles (e.g. VSCrashReporterMac.app) by falling through to bare binary
- Add quarantine attribute removal (xattr) for downloaded game versions (eg. xattr -cr )
- Extend chmod support to darwin platform
- Add macOS download URLs for game versions
- Configure electron-builder for macOS arm64 DMG builds
- Improve error reporting: return detailed error messages from game handler instead of boolean, surface stderr in UI notifications with clickable button to open logs folder
- Pin axios to <=1.14.0 - 1.14.1 had a supply chain attack.

There is no signing for VS Launcher so:
xattr -cr "/Applications/VS Launcher.app"