### PR TITLE
Fix português (brasil) translation error

### DIFF
--- a/src/renderer/src/features/home/pages/HomePage.tsx
+++ b/src/renderer/src/features/home/pages/HomePage.tsx
@@ -10,7 +10,7 @@ function HomePage(): JSX.Element {
       <p className="text-lg">{t("features.home.description")}</p>
 
       <iframe
-        src="https://www.youtube.com/embed/wsyy8pziGLI?si=S1TlAWsMNpjGRyjr"
+        src="https://www.youtube-nocookie.com/embed/wsyy8pziGLI"
         title="Promotional Video"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         referrerPolicy="strict-origin-when-cross-origin"

--- a/src/renderer/src/i18n.ts
+++ b/src/renderer/src/i18n.ts
@@ -24,7 +24,7 @@ i18n.use(initReactI18next).init({
     "fr-FR": { translation: frFR, name: "Français", credits: "by LorIlcs" },
     "de-DE": { translation: deDE, name: "Deutsch", credits: "by Brady_The" },
     "pt-PT": { translation: ptPT, name: "Português", credits: "by Bruno Cabrita" },
-    "pt-BR": { translation: ptPT, name: "Português (Brasil)", credits: "by Paulo Nascimento" },
+    "pt-BR": { translation: ptBR, name: "Português (Brasil)", credits: "by Paulo Nascimento" },
     "nl-NL": { translation: nlNL, name: "Dutch (Netherlands)", credits: "by Dennisjeee" },
     "pl-PL": { translation: plPL, name: "Polski", credits: "by Runo Hawk, Zsuatem" },
     "it-IT": { translation: itIT, name: "Italiano", credits: "by Pingoda" },


### PR DESCRIPTION
i18n.ts was referencing the "pt-PT" translation twice. This caused an error on build as ptBR was imported in the file but was never referenced. In my installed build, Português translation was shown as an option but Português (Brasil) was missing. This fix should add Português (Brasil) in the language dropdown. 