### PR TITLE
Fix Brazilian Portuguese translation being improperly referenced

### DIFF
--- a/src/renderer/src/i18n.ts
+++ b/src/renderer/src/i18n.ts
@@ -24,7 +24,7 @@ i18n.use(initReactI18next).init({
     "fr-FR": { translation: frFR, name: "Français", credits: "by LorIlcs" },
     "de-DE": { translation: deDE, name: "Deutsch", credits: "by Brady_The" },
     "pt-PT": { translation: ptPT, name: "Português", credits: "by Bruno Cabrita" },
-    "pt-BR": { translation: ptPT, name: "Português (Brasil)", credits: "by Paulo Nascimento" },
+    "pt-BR": { translation: ptBR, name: "Português (Brasil)", credits: "by Paulo Nascimento" },
     "nl-NL": { translation: nlNL, name: "Dutch (Netherlands)", credits: "by Dennisjeee" },
     "pl-PL": { translation: plPL, name: "Polski", credits: "by Runo Hawk, Zsuatem" },
     "it-IT": { translation: itIT, name: "Italiano", credits: "by Pingoda" },


### PR DESCRIPTION
I was packaging VS Launcher for Nix and noticed a small typo in the logs. Sending up a patch to quickly fix that.
Previously, the following warning was thrown (and this fixes it):
```
src/renderer/src/i18n.ts:11:1 - error TS6133: 'ptBR' is declared but its value is never read.
```